### PR TITLE
Workaround for revert message in rsk

### DIFF
--- a/deploy/deploy.js
+++ b/deploy/deploy.js
@@ -12,12 +12,19 @@ const chainName = (chainId) => {
     case 4: return 'Rinkeby';
     case 5: return 'Goerli';
     case 42: return 'Kovan';
+    case 30: return 'RskMainnet';
+    case 31: return 'RskTestnet';
+    case 33: return 'RskRegtest';
     case 31337: return 'BuidlerEVM';
     default: return 'Unknown';
   }
 }
 
 module.exports = async (buidler) => {
+  const format = buidler.ethers.provider.formatter.formats
+  format.receipt['root'] = format.receipt['logsBloom']
+  Object.assign(buidler.ethers.provider.formatter, { format: format })
+
   const { getNamedAccounts, deployments, getChainId, ethers } = buidler
   const { deploy, getOrNull, save } = deployments
 
@@ -32,12 +39,12 @@ module.exports = async (buidler) => {
   const chainId = parseInt(await getChainId(), 10)
   const isLocal = [1, 3, 4, 42].indexOf(chainId) == -1
   // 31337 is unit testing, 1337 is for coverage
-  const isTestEnvironment = chainId === 31337 || chainId === 1337
+  const isTestEnvironment = chainId === 31337 || chainId === 1337 || chainId === 33
   let usingSignerAsAdmin = false
   const signer = await ethers.provider.getSigner(deployer)
 
   debug("\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-  debug("PoolTogether Pool Contracts - Deploy Script")
+  debug("Coin Tanda Contracts - Deploy Script")
   debug("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n")
 
   const locus = isLocal ? 'local' : 'remote'

--- a/test/CompoundPrizePool.test.js
+++ b/test/CompoundPrizePool.test.js
@@ -11,6 +11,7 @@ const IERC721 = require('../build/IERC721.json')
 const { ethers } = require('ethers')
 const { expect } = require('chai')
 const buidler = require('./helpers/buidler')
+const { revertedWith, notRevertedWith} = require('./helpers/revertedWith')
 
 const toWei = ethers.utils.parseEther
 
@@ -90,7 +91,7 @@ describe('CompoundPrizePool', function() {
 
       await erc20token.mock.approve.withArgs(cToken.address, amount).returns(true)
       await cToken.mock.mint.returns('1')
-      await expect(prizePool.supply(amount)).to.be.revertedWith('CompoundPrizePool/mint-failed')
+      await revertedWith(prizePool.callStatic.supply(amount), 'CompoundPrizePool/mint-failed')
     })
   })
 

--- a/test/Comptroller.test.js
+++ b/test/Comptroller.test.js
@@ -6,6 +6,7 @@ const { deployContract } = require('ethereum-waffle')
 const { deployMockContract } = require('./helpers/deployMockContract')
 const { AddressZero } = require("ethers").constants
 const { call } = require('./helpers/call')
+const { revertedWith, notRevertedWith} = require('./helpers/revertedWith')
 
 const toWei = ethers.utils.parseEther
 
@@ -62,7 +63,7 @@ describe('Comptroller', () => {
     })
 
     it('should not allow anyone else to configure the reserve rate', async () => {
-      await expect(comptroller2.setReserveRateMantissa(toWei('0.2'))).to.be.revertedWith("Ownable: caller is not the owner")
+      await revertedWith(comptroller2.callStatic.setReserveRateMantissa(toWei('0.2')), 'Ownable: caller is not the owner')
     })
   })
 
@@ -77,7 +78,7 @@ describe('Comptroller', () => {
     })
 
     it('should allow only the owner to add drips', async () => {
-      await expect(comptroller2.activateBalanceDrip(prizePoolAddress, measure.address, dripToken.address, toWei('0.001'))).to.be.revertedWith("Ownable: caller is not the owner")
+      await revertedWith(comptroller2.callStatic.activateBalanceDrip(prizePoolAddress, measure.address, dripToken.address, toWei('0.001')), "Ownable: caller is not the owner")
     })
   })
 
@@ -96,7 +97,7 @@ describe('Comptroller', () => {
     })
 
     it('should allow only the owner to remove drips', async () => {
-      await expect(comptroller2.deactivateBalanceDrip(prizePoolAddress, measure.address, dripToken.address, SENTINEL)).to.be.revertedWith("Ownable: caller is not the owner")
+      await revertedWith(comptroller2.callStatic.deactivateBalanceDrip(prizePoolAddress, measure.address, dripToken.address, SENTINEL), "Ownable: caller is not the owner")
     })
   })
 
@@ -115,7 +116,7 @@ describe('Comptroller', () => {
     })
 
     it('should not allow anyone else to update the drip rate', async () => {
-      await expect(comptroller2.setBalanceDripRate(wallet._address, measure.address, dripToken.address, toWei('0.1'))).to.be.revertedWith('Ownable: caller is not the owner')
+      await revertedWith(comptroller2.callStatic.setBalanceDripRate(wallet._address, measure.address, dripToken.address, toWei('0.1')), 'Ownable: caller is not the owner')
     })
   })
 
@@ -179,8 +180,8 @@ describe('Comptroller', () => {
     })
 
     it('should not allow anyone else', async () => {
-      await expect(
-        comptroller2.activateVolumeDrip(
+      await revertedWith(
+        comptroller2.callStatic.activateVolumeDrip(
           prizePoolAddress,
           measure.address,
           dripToken.address,
@@ -188,8 +189,8 @@ describe('Comptroller', () => {
           10,
           toWei('100'),
           10
-        )
-      ).to.be.revertedWith("Ownable: caller is not the owner")
+        ),
+      "Ownable: caller is not the owner")
     })
   })
 
@@ -236,15 +237,15 @@ describe('Comptroller', () => {
         10
       )
 
-      await expect(
-        comptroller2.deactivateVolumeDrip(
+      await revertedWith(
+        comptroller2.callStatic.deactivateVolumeDrip(
           prizePoolAddress,
           measure.address,
           dripToken.address,
           false,
           SENTINEL
-        )
-      ).to.be.revertedWith("Ownable: caller is not the owner")
+        ),
+        "Ownable: caller is not the owner")
     })
   })
 
@@ -302,16 +303,16 @@ describe('Comptroller', () => {
         10
       )
 
-      await expect(
-        comptroller2.setVolumeDrip(
+      await revertedWith(
+        comptroller2.callStatic.setVolumeDrip(
           prizePoolAddress,
           measure.address,
           dripToken.address,
           false,
           20,
           toWei('200')
-        )
-      ).to.be.revertedWith("Ownable: caller is not the owner")
+        ),
+      "Ownable: caller is not the owner")
     })
   })
 

--- a/test/ControlledToken.test.js
+++ b/test/ControlledToken.test.js
@@ -2,6 +2,7 @@ const { expect } = require("chai");
 const ControlledToken = require('../build/ControlledToken.json')
 const TokenControllerInterface = require('../build/TokenControllerInterface.json')
 const buidler = require('./helpers/buidler')
+const { revertedWith, notRevertedWith} = require('./helpers/revertedWith')
 const { deployContract } = require('ethereum-waffle')
 const { deployMockContract } = require('./helpers/deployMockContract')
 
@@ -75,8 +76,8 @@ describe('ControlledToken', () => {
       await controller.mock.beforeTokenTransfer.returns()
 
       await controller.call(token, 'controllerMint', wallet._address, toWei('10'))
-      await expect(controller.call(token, 'controllerBurnFrom', wallet2._address, wallet._address, toWei('10')))
-        .to.be.revertedWith('ControlledToken/exceeds-allowance')
+      await revertedWith(controller.callStatic.call(token, 'controllerBurnFrom', wallet2._address, wallet._address, toWei('10')),
+        'ControlledToken/exceeds-allowance')
     })
 
     it('should allow a user to burn their own', async () => {

--- a/test/ExtendedSafeCastExposed.test.js
+++ b/test/ExtendedSafeCastExposed.test.js
@@ -4,6 +4,7 @@ const ExtendedSafeCastExposed = require('../build/ExtendedSafeCastExposed.json')
 const { ethers } = require('ethers')
 const { expect } = require('chai')
 const buidler = require('./helpers/buidler')
+const { revertedWith, notRevertedWith} = require('./helpers/revertedWith')
 
 const toWei = ethers.utils.parseEther
 
@@ -30,7 +31,7 @@ describe('ExtendedSafeCastExposed', function() {
     })
 
     it('should throw on overflow', async () => {
-      await expect(cast.toUint112(MAX_112)).to.be.revertedWith("SafeCast: value doesn't fit in an uint112")
+      await revertedWith(cast.callStatic.toUint112(MAX_112), "SafeCast: value doesn't fit in an uint112")
     })
   })
 
@@ -40,7 +41,7 @@ describe('ExtendedSafeCastExposed', function() {
     })
 
     it('should throw on overflow', async () => {
-      await expect(cast.toUint96(MAX_96)).to.be.revertedWith("SafeCast: value doesn't fit in an uint96")
+      await revertedWith(cast.callStatic.toUint96(MAX_96), "SafeCast: value doesn't fit in an uint96")
     })
   })
 

--- a/test/MappedSinglyLinkedListExposed.test.js
+++ b/test/MappedSinglyLinkedListExposed.test.js
@@ -4,6 +4,7 @@ const MappedSinglyLinkedListExposed = require('../build/MappedSinglyLinkedListEx
 const { ethers } = require('ethers')
 const { expect } = require('chai')
 const buidler = require('./helpers/buidler')
+const { revertedWith, notRevertedWith} = require('./helpers/revertedWith')
 const { AddressZero } = require('ethers').constants
 
 const toWei = ethers.utils.parseEther
@@ -32,7 +33,7 @@ describe('MappedSinglyLinkedListExposed', function() {
     })
 
     it('should not be initialized after it contains values', async () => {
-      await expect(list.initialize()).to.be.revertedWith('Already init')
+      await revertedWith(list.callStatic.initialize(), 'Already init')
     })
   })
 
@@ -44,11 +45,11 @@ describe('MappedSinglyLinkedListExposed', function() {
 
   describe('addAddress', () => {
     it('should not allow adding the SENTINEL address', async () => {
-      await expect(list.addAddress(SENTINEL)).to.be.revertedWith("Invalid address")
+      await revertedWith(list.callStatic.addAddress(SENTINEL), "Invalid address")
     })
 
     it('should not allow adding a zero address', async () => {
-      await expect(list.addAddress(AddressZero)).to.be.revertedWith("Invalid address")
+      await revertedWith(list.callStatic.addAddress(AddressZero), "Invalid address")
     })
 
     it('should allow the user to add an address', async () => {
@@ -60,15 +61,15 @@ describe('MappedSinglyLinkedListExposed', function() {
 
   describe('removeAddress', () => {
     it('should not allow removing the SENTINEL address', async () => {
-      await expect(list.removeAddress(SENTINEL, SENTINEL)).to.be.revertedWith("Invalid address")
+      await revertedWith(list.callStatic.removeAddress(SENTINEL, SENTINEL), "Invalid address")
     })
 
     it('should not allow removing an address that does not exist', async () => {
-      await expect(list.removeAddress(wallet._address, wallet2._address)).to.be.revertedWith("Invalid prevAddress")
+      await revertedWith(list.callStatic.removeAddress(wallet._address, wallet2._address), "Invalid prevAddress")
     })
 
     it('should not allow removing a zero address', async () => {
-      await expect(list.removeAddress(wallet._address, AddressZero)).to.be.revertedWith("Invalid address")
+      await revertedWith(list.callStatic.removeAddress(wallet._address, AddressZero), "Invalid address")
     })
 
     it('should allow the user to add an address', async () => {

--- a/test/UInt256ArrayExposed.test.js
+++ b/test/UInt256ArrayExposed.test.js
@@ -4,6 +4,7 @@ const UInt256ArrayExposed = require('../build/UInt256ArrayExposed.json')
 const { ethers } = require('ethers')
 const { expect } = require('chai')
 const buidler = require('./helpers/buidler')
+const { revertedWith, notRevertedWith} = require('./helpers/revertedWith')
 
 const debug = require('debug')('ptv3:UInt256ArrayExposed.test')
 
@@ -14,14 +15,14 @@ describe('UInt256ArrayExposed', function() {
   let array
 
   beforeEach(async () => {
-    [wallet, wallet2, wallet3, wallet4] = await buidler.ethers.getSigners()    
+    [wallet, wallet2, wallet3, wallet4] = await buidler.ethers.getSigners()
   })
 
   describe('remove()', () => {
     it('should error when index is out of range', async () => {
       array = await deployContract(wallet, UInt256ArrayExposed, [[1, 2, 3, 4]], overrides)
 
-      await expect(array.remove(5)).to.be.revertedWith("UInt256Array/unknown-index")
+      await revertedWith(array.callStatic.remove(5), "UInt256Array/unknown-index")
     })
 
     it('should work', async () => {

--- a/test/VolumeDripManagerExposed.test.js
+++ b/test/VolumeDripManagerExposed.test.js
@@ -6,6 +6,7 @@ const IERC20 = require('../build/IERC20.json')
 const { ethers } = require('ethers')
 const { expect } = require('chai')
 const buidler = require('./helpers/buidler')
+const { revertedWith, notRevertedWith} = require('./helpers/revertedWith')
 const { AddressZero } = require('ethers').constants
 
 const toWei = ethers.utils.parseEther
@@ -63,7 +64,7 @@ describe('VolumeDripManagerExposed', function() {
 
     it('should not allow a drip to be re-activated', async () => {
       await manager.activate(measure.address, drip1.address, periodSeconds, dripAmount, 30)
-      await expect(manager.activate(measure.address, drip1.address, periodSeconds, dripAmount, 30)).to.be.revertedWith("VolumeDripManager/drip-active")
+      await revertedWith(manager.callStatic.activate(measure.address, drip1.address, periodSeconds, dripAmount, 30), "VolumeDripManager/drip-active")
     })
   })
 
@@ -86,7 +87,7 @@ describe('VolumeDripManagerExposed', function() {
     })
 
     it('should revert for inactive drips', async () => {
-      await expect(manager.set(measure.address, drip1.address, periodSeconds, dripAmount)).to.be.revertedWith("VolumeDripManager/drip-not-active")
+      await revertedWith(manager.callStatic.set(measure.address, drip1.address, periodSeconds, dripAmount), "VolumeDripManager/drip-not-active")
     })
   })
 

--- a/test/features/support/PoolEnv.js
+++ b/test/features/support/PoolEnv.js
@@ -351,10 +351,6 @@ function PoolEnv() {
     debug('award completed')
   }
 
-  this.expectRevertWith = async function (promise, msg) {
-    await expect(promise).to.be.revertedWith(msg)
-  }
-
   this.awardPrize = async function () {
     await this.awardPrizeToToken({ token: 0 })
   }

--- a/test/features/tickets.test.js
+++ b/test/features/tickets.test.js
@@ -39,9 +39,19 @@ describe('Tickets Feature', () => {
     await env.buyTickets({ user: 2, tickets: 100 })
     await env.startAward()
 
-    await env.expectRevertWith(env.buyTickets({ user: 1, tickets: 100 }), "PeriodicPrizeStrategy/rng-in-flight")
+    try {
+      await env.callStatic.buyTickets({ user: 1, tickets: 100 })
+      assert.fail('transaction not reverted');
+    } catch (err) {
+      expect(err.message).to.include('PeriodicPrizeStrategy/rng-in-flight')
+    }
 
-    await env.expectRevertWith(env.transferTickets({ user: 2, tickets: 100, to: 3 }), "PeriodicPrizeStrategy/rng-in-flight")
+    try {
+      await env.callStatic.transferTickets({ user: 2, tickets: 100, to: 3 })
+      assert.fail('transaction not reverted');
+    } catch (err) {
+      expect(err.message).to.include('PeriodicPrizeStrategy/rng-in-flight')
+    }
 
     await env.completeAward({ token: 0 })
 

--- a/test/helpers/revertedWith.js
+++ b/test/helpers/revertedWith.js
@@ -1,0 +1,22 @@
+const { expect } = require('chai')
+
+const revertedWith = async (promise, errMsg) => {
+  try {
+    await promise
+    assert.fail('transaction not reverted');
+  } catch (err) {
+    expect(err.message).to.include(errMsg)
+  }
+}
+
+const notRevertedWith = async (promise, errMsg) => {
+  try {
+    await promise
+    assert.fail('transaction not reverted');
+  } catch (err) {
+    expect(err.message).not.to.include(errMsg)
+  }
+}
+
+
+module.exports  = { revertedWith, notRevertedWith }

--- a/test/yVaultPrizePool.test.js
+++ b/test/yVaultPrizePool.test.js
@@ -10,6 +10,7 @@ const ERC20Mintable = require('../build/ERC20Mintable.json')
 const { ethers } = require('ethers')
 const { expect } = require('chai')
 const buidler = require('./helpers/buidler')
+const { revertedWith, notRevertedWith} = require('./helpers/revertedWith')
 
 const toWei = ethers.utils.parseEther
 
@@ -103,7 +104,7 @@ describe('yVaultPrizePool', function() {
     })
 
     it('should revert if reserve is exceeded', async () => {
-      await expect(prizePool.redeem(amount)).to.be.revertedWith("yVaultPrizePool/insuff-liquidity")
+      await revertedWith(prizePool.callStatic.redeem(amount), "yVaultPrizePool/insuff-liquidity")
     })
 
     it('should allow a user to withdraw', async () => {


### PR DESCRIPTION
Waffle revertWith does not work correctly with RSK
Also RSK does not return the error from a reverted message unless you use a call, to force this in waffle we need to use callStatic